### PR TITLE
Patch gazelle generated BUILD file by including dynamic libraries

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,3 +30,11 @@ use_repo(
     go_deps,
     "com_github_kuzudb_go_kuzu",
 )
+
+go_deps.module_override(
+    patches = [
+        "//patches:kuzu-bazel.patch",
+    ],
+    path = "github.com/kuzudb/go-kuzu", # The path to the module being patched
+)
+

--- a/patches/kuzu-bazel.patch
+++ b/patches/kuzu-bazel.patch
@@ -1,0 +1,28 @@
+--- BUILD.bazel	2025-09-02 17:12:47
++++ BUILD.bazel	2025-09-02 18:43:54
+@@ -1,5 +1,17 @@
+ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+ 
++cc_library(
++    name = "dynamic_libs",
++    srcs = select({
++        "@io_bazel_rules_go//go/platform:darwin": ["lib/dynamic/darwin/libkuzu.dylib"],
++        "@io_bazel_rules_go//go/platform:windows": ["lib/dynamic/windows/kuzu_shared.dll", "lib/dynamic/windows/kuzu_shared.lib"],
++        "@io_bazel_rules_go//go/platform:linux_amd64":["lib/dynamic/linux-amd64/libkuzu.so"],
++        "@io_bazel_rules_go//go/platform:linux_arm64":["lib/dynamic/linux-arm64/libkuzu.so"],
++     
++    }),
++)
++
++
+ go_library(
+     name = "go-kuzu",
+     srcs = [
+@@ -14,6 +26,7 @@
+         "time_helper.go",
+         "value_helper.go",
+     ],
++    cdeps = [":dynamic_libs"],
+     cgo = True,
+     clinkopts = select({
+         "@io_bazel_rules_go//go/platform:darwin": [


### PR DESCRIPTION
At presented tested only in mac, I'll test it on linux separately.

The patch file is generated using `diff -Naur `
And fix the filenames at the top of the generated diffs. The filename must be relative to the root of the github repository that is imported. In my case, it is the top level BUILD.bazel.

And in the MODULE.bazel, include this patch
```
go_deps.module_override(
    patches = [
        "//patches:kuzu-bazel.patch",
    ],
    path = "github.com/kuzudb/go-kuzu", # The path to the module being patched
)

```
